### PR TITLE
[codex] Remove hero catchphrase

### DIFF
--- a/app/components/home-content.tsx
+++ b/app/components/home-content.tsx
@@ -46,13 +46,6 @@ export function HomeContent({ posts }: HomeContentProps) {
           <br />
           DAICHI
         </h1>
-        <div className="mt-8 grid grid-cols-4 md:grid-cols-12 gap-6">
-          <div className="col-span-4 md:col-span-5 md:col-start-8">
-            <p className="text-lg md:text-xl leading-tight font-medium text-secondary font-[family-name:var(--font-zen-kaku)]">
-              テクノロジーで生身では成せないことを成す
-            </p>
-          </div>
-        </div>
       </motion.div>
 
       {/* Current Status - Grid Layout */}


### PR DESCRIPTION
## Summary

Remove the Japanese hero catchphrase from the home page.

## Impact

The home hero now shows only the name heading, without leaving the removed catchphrase container or extra spacing behind.

## Validation

- pnpm build

Note: the first build attempt failed in the sandbox because next/font could not fetch Google Fonts without network access. The build passed after rerunning with network access.